### PR TITLE
Add Document Deserialization

### DIFF
--- a/lib/jsonapi/deserializable.rb
+++ b/lib/jsonapi/deserializable.rb
@@ -1,2 +1,33 @@
 require 'jsonapi/deserializable/relationship'
 require 'jsonapi/deserializable/resource'
+require 'jsonapi/deserializable/document'
+require 'logger'
+
+module JSONAPI
+  module Deserializable
+
+    class << self
+
+      def log
+        @logger ||= initialize_logger
+      end
+
+      private
+
+      def initialize_logger
+        logger = Logger.new(log_output)
+        logger.level = Logger::DEBUG
+        logger.datetime_format = "%Y-%m-%d %H:%M:%S "
+        logger
+      end
+
+      def log_output
+        if defined?(Rails)
+          "log/#{Rails.env}.log"
+        else
+          STDOUT
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/deserializable/document.rb
+++ b/lib/jsonapi/deserializable/document.rb
@@ -1,0 +1,152 @@
+require "jsonapi/deserializable/errors/errors"
+require "jsonapi/deserializable/document/related_resources"
+
+module JSONAPI
+  module Deserializable
+    class Document
+      def initialize(payload)
+        @data = payload["data"]
+        @resource_deserializer = self.class.resource_deserializer_klass
+        @included_resources = payload["included"]
+        @related_resources = RelatedResources.new(included_resources)
+        @relationship_to_include = retrieve_included_relationship_keys
+      end
+
+      class << self
+
+        attr_reader(
+          :resource_deserializer_klass,
+          :relationship_to_include_keys
+        )
+
+        def call(payload)
+          new(payload).to_a
+        end
+
+        def process_each_resource(payload, &block)
+          new(payload).each_resource(&block)
+        end
+
+        private
+
+        def resource_deserializer(klass)
+          @resource_deserializer_klass = klass
+        end
+
+        def relationship_to_include(*keys)
+          @relationship_to_include_keys = keys
+        end
+      end
+
+      def to_a
+        fail Errors::NoDeserializableResource unless deserializer_present?
+        deserialize
+        if data.is_a? Array
+          process_resources_collection
+        else
+          log(data)
+          resource_deserializer.call(data)
+        end
+      end
+
+      def each_resource(&block)
+        fail Utils::NoDeserializableResource unless deserializer_present?
+        return unless data.is_a? Array
+        data.each do |resource|
+          map_related_resource_for(resource)
+          log(resource)
+          yield resource_deserializer.call(resource)
+        end
+      end
+
+      private
+
+      attr_reader(
+        :resource_deserializer,
+        :data,
+        :included_resources,
+        :relationship_to_include,
+        :related_resources
+      )
+
+      def deserialize
+        return if no_included_relationship?
+        if data.is_a? Array
+          map_related_resources
+        else
+          map_related_resource_for data
+        end
+      end
+
+      def retrieve_included_relationship_keys
+        self.class.relationship_to_include_keys || default_options
+      end
+
+      def default_options
+        return if no_included_relationship?
+        resource_relationships.keys
+      end
+
+      def resource_relationships
+        if data.is_a? Array
+          data[0]["relationships"]
+        else
+          data["relationships"]
+        end
+      end
+
+      def map_related_resources
+        data.each do |resource|
+          map_related_resource_for resource
+        end
+      end
+
+      def map_related_resource_for(resource)
+        return if relationship_to_include.nil?
+        relationships = resource["relationships"]
+        if !relationships.nil?
+          relationship_to_include.each do |key|
+            related_data = relationships[key]["data"]
+            relationships[key]["data"] = merge_included_data(related_data)
+          end
+        end
+      end
+
+      def merge_included_data(resource_data)
+        if resource_data.is_a? Array
+          get_related_resources_collection(resource_data)
+        else
+          related_resources.get_resources_for(resource_data)
+        end
+      end
+
+      def get_related_resources_collection(resource_data)
+        resource_data.map do |resource|
+          related_resources.get_resources_for(resource)
+        end
+      end
+
+      def no_included_relationship?
+        included_resources.nil? || included_resources.empty?
+      end
+
+      def deserializer_present?
+        !resource_deserializer.nil?
+      end
+
+      def process_resources_collection
+        data.map do |resource|
+          log(resource)
+          resource_deserializer.call(resource)
+        end
+      end
+
+      def log(resource)
+        message = "#{self.class}: Deserializing #{resource}"
+        JSONAPI::Deserializable.log.info(message)
+      end
+    end
+  end
+end
+
+

--- a/lib/jsonapi/deserializable/document/related_resources.rb
+++ b/lib/jsonapi/deserializable/document/related_resources.rb
@@ -1,0 +1,36 @@
+module JSONAPI
+  module Deserializable
+    class RelatedResources
+      def initialize(resources)
+        return if resources.nil?
+        @resources = grouped_resources_by_types(resources)
+        sort_resources(@resources)
+      end
+
+      def get_resources_for(related_resource)
+        type = related_resource["type"]
+        resources[type].bsearch do |resource|
+          related_resource["id"] <=> resource["id"]
+        end
+      end
+
+      private
+
+      attr_reader :resources, :grouped_resources
+
+      def grouped_resources_by_types(resources)
+        resources.group_by do |resource|
+          resource["type"]
+        end
+      end
+
+      def sort_resources(resources)
+        resources.each_pair do |_type, grouped_resources|
+          grouped_resources.sort! do |a, b|
+            a["id"] <=> b["id"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/jsonapi/deserializable/errors/errors.rb
+++ b/lib/jsonapi/deserializable/errors/errors.rb
@@ -1,0 +1,8 @@
+module JSONAPI
+  module Deserializable
+    module Errors
+      class NoDeserializableResource < StandardError
+      end
+    end
+  end
+end

--- a/spec/document/document_spec.rb
+++ b/spec/document/document_spec.rb
@@ -1,0 +1,246 @@
+require "spec_helper"
+
+describe JSONAPI::Deserializable::Document do
+
+  describe ".call" do
+    it "logs the data being processed" do
+      document_deseriaizer = build_document_deserializer(
+        relationship_to_include: nil
+      )
+      logger = stub_logger
+
+      document_deseriaizer.call(payload_without_included_data)
+
+      expect(logger).to have_received(:info)
+    end
+
+    context "when resource_deserializer is present" do
+      it "calls the deserializer when deserializing the document" do
+        stub_logger
+        deserializer = resource_deserializer
+        document_deseriaizer = build_document_deserializer(
+          relationship_to_include: nil,
+          deserializer: deserializer
+        )
+
+        document_deseriaizer.call(payload_without_included_data)
+
+        expect(deserializer).to have_received(:call).once
+      end
+    end
+
+    context "when resource_deserializer is not present" do
+      it "raises NoDeserializableResource error" do
+        stub_logger
+        document_deseriaizer = Class.new(JSONAPI::Deserializable::Document) do
+          resource_deserializer nil
+        end
+        error = JSONAPI::Deserializable::Errors::NoDeserializableResource
+
+        expect do
+          document_deseriaizer.call(payload_without_included_data)
+        end.to raise_error(error)
+      end
+
+      context "when relationship_to_include is present" do
+        it "includes the related resource in the data hash" do
+          stub_logger
+          deserializer = resource_deserializer
+          document_deseriaizer = build_document_deserializer(
+            relationship_to_include: "test1",
+            deserializer: deserializer
+          )
+          doc = payload_document("test", 1, "test1", 2)
+          resource_with_related_data = {
+            "type" => "test",
+            "id" => 1,
+            "relationships" => {
+              "test1" => {
+                "data" => {
+                  "type" => "test1",
+                  "id" => 2,
+                  "attributes" => {
+                    "name" => "test relationship 1",
+                  },
+                },
+              },
+            },
+          }
+
+          document_deseriaizer.call(doc)
+
+          expect(deserializer).to have_received(:call).with(
+            resource_with_related_data
+          )
+        end
+      end
+
+      context "when relationship_to_include is not present" do
+        it "includes all the relationships it can find in the data hash" do
+          stub_logger
+          deserializer = resource_deserializer
+          document_deseriaizer = Class.new(JSONAPI::Deserializable::Document) do
+            resource_deserializer deserializer
+          end
+          doc = {
+            "data" =>
+              {
+                "type" => "test",
+                "id" => 1,
+                "relationships" => {
+                  "test1" => {
+                    "data" => {
+                      "type" => "test1",
+                      "id" => 2,
+                    },
+                  },
+                  "test2" => {
+                    "data" => {
+                      "type" => "test2",
+                      "id" => 3,
+                    },
+                  },
+                },
+              },
+            "included" => [
+              {
+                "type" => "test1",
+                "id" => 2,
+                "attributes" => {
+                  "name" => "test relationship 1",
+                },
+              },
+              {
+                "type" => "test2",
+                "id" => 3,
+                "attributes" => {
+                  "name" => "test relationship 2",
+                },
+              },
+            ],
+          }
+          resource_with_related_data = {
+            "type" => "test",
+            "id" => 1,
+            "relationships" => {
+              "test1" => {
+                "data" => {
+                  "type" => "test1",
+                  "id" => 2,
+                  "attributes" => {
+                    "name" => "test relationship 1",
+                  },
+                },
+              },
+              "test2" => {
+                "data" => {
+                  "type" => "test2",
+                  "id" => 3,
+                  "attributes" => {
+                    "name" => "test relationship 2",
+                  },
+                },
+              },
+            },
+          }
+
+          document_deseriaizer.call(doc)
+
+          expect(deserializer).to have_received(:call).with(
+            resource_with_related_data
+          )
+        end
+      end
+    end
+
+  end
+
+  describe ".process_each_resource" do
+    context "when document is an array" do
+      it "yields deserialized resources" do
+        stub_logger
+        document_deseriaizer = build_document_deserializer(
+          relationship_to_include: "test1"
+        )
+        doc = payload_document("test", 1, "test1", 2)
+
+        expect do |block|
+          document_deseriaizer.process_each_resource(doc, &block)
+        end.to yield_with_args
+      end
+    end
+
+    context "when document is not an array" do
+      it "does not yield to block" do
+        stub_logger
+        
+        document_deseriaizer = build_document_deserializer(
+          relationship_to_include: "test1"
+        )
+        doc = payload_without_included_data(type: "test1")
+
+        expect do |block|
+          document_deseriaizer.process_each_resource(doc, &block)
+        end.not_to yield_with_args
+      end
+    end
+  end
+
+  def resource_deserializer
+    deserializer = class_double("Deserializer", call: {})
+    allow(deserializer).to receive(:call)
+    deserializer
+  end
+
+  def stub_logger
+    logger = Logger.new(STDOUT)
+    allow(Logger).to receive(:new).and_return(logger)
+    allow(logger).to receive(:info)
+    logger
+  end
+
+  def payload_without_included_data(type: "test1")
+    {
+      "data" => {
+        "type" => type,
+        "id" => 1,
+      },
+    }
+  end
+
+  def payload_document(type, id, relationship_type, relationship_id)
+    {
+      "data" =>
+        [{
+          "type" => type,
+          "id" => id,
+          "relationships" => {
+            "#{relationship_type}" => {
+              "data" => {
+                "type" => relationship_type,
+                "id" => 2,
+              },
+            },
+          },
+        }],
+      "included" => [
+        {
+          "type" => relationship_type,
+          "id" => relationship_id,
+          "attributes" => {
+            "name" => "test relationship 1",
+          },
+        },
+      ],
+    }
+  end
+
+  def build_document_deserializer(relationship_to_include: "test1", 
+                                  deserializer: nil)
+    deserializer ||= resource_deserializer
+    Class.new(JSONAPI::Deserializable::Document) do
+      resource_deserializer deserializer
+      relationship_to_include relationship_to_include
+    end
+  end
+end


### PR DESCRIPTION
Add Document Deserialization

We need a way to combine a resource and it's included resources in the `included` array. This will ensure that we are deserializing a resource completely with all the necessary data all in one place.

This change addresses this need by:

* adding a `Document` class to handle the merging of a resource and it's included data before 
  deserializing the single resource
* adding specs to ensure confirm functionality